### PR TITLE
Add a framework for writing gdb integration tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,10 @@ language: rust
 sudo: false
 os:
 - linux
+addons:
+  apt:
+    packages:
+    - gdb
 rust:
   - nightly
   - beta

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,3 +9,7 @@ license = "Apache-2.0/MIT"
 nom = "3.2.0"
 strum = "0.8.0"
 strum_macros = "0.8.0"
+
+[dev-dependencies]
+assert_cli = "0.5.4"
+which = "1.0.3"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -645,6 +645,7 @@ pub enum Error {
 /// The `qAttached` packet lets the client distinguish between
 /// attached and created processes, so that it knows whether to send a
 /// detach request when disconnecting.
+#[derive(Clone, Copy)]
 pub enum ProcessType {
     /// The process already existed and was attached to.
     Attached,
@@ -653,6 +654,7 @@ pub enum ProcessType {
 }
 
 /// The possible reasons for a thread to stop.
+#[derive(Clone, Copy)]
 pub enum StopReason {
     /// Process stopped due to a signal.
     Signal(u8),

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1,0 +1,106 @@
+// GDB integration tests
+
+extern crate assert_cli;
+extern crate gdb_remote_protocol;
+extern crate which;
+
+use assert_cli::Assert;
+use gdb_remote_protocol::{Error, Handler, ProcessType, process_packets_from, StopReason};
+use std::net::TcpListener;
+use std::thread;
+
+struct TestHandler {
+    process_type: ProcessType,
+    stop_reason: StopReason,
+}
+
+impl Default for TestHandler {
+    fn default() -> TestHandler {
+        TestHandler {
+            process_type: ProcessType::Created,
+            stop_reason: StopReason::Exited(23, 0),
+        }
+    }
+}
+
+impl Handler for TestHandler {
+    fn attached(&self, _pid: Option<u64>) -> Result<ProcessType, Error> {
+        Ok(self.process_type)
+    }
+
+    fn halt_reason(&self) -> Result<StopReason, Error> {
+        Ok(self.stop_reason)
+    }
+}
+
+struct GDBTestBuilder {
+    assert: Assert,
+    handler: TestHandler,
+    listener: TcpListener,
+}
+
+#[allow(unused)]
+impl GDBTestBuilder {
+    /// Add `cmd` to the list of GDB commands to execute.
+    fn command<T>(self, cmd: T) -> GDBTestBuilder
+        where T: AsRef<str>,
+    {
+        let GDBTestBuilder { assert, handler, listener } = self;
+        GDBTestBuilder { assert: assert.with_args(&["-ex", cmd.as_ref()]), handler, listener }
+    }
+
+    /// Add assertions for the GDB process. `f` will receive an `Assert` that can
+    /// be used to add assertions and must return it.
+    fn assert<F>(self, f: F) -> GDBTestBuilder
+        where F: FnOnce(Assert) -> Assert,
+    {
+        let GDBTestBuilder { assert, handler, listener } = self;
+        let assert = f(assert);
+        GDBTestBuilder { assert, handler, listener }
+    }
+
+    /// Change the behavior of the `TestHandler`. `f` will receive a `&mut TestHandler` argument
+    /// which can be changed as desired.
+    fn handler<F>(self, f: F) -> GDBTestBuilder
+        where F: FnOnce(&mut TestHandler),
+    {
+        let GDBTestBuilder { assert, mut handler, listener } = self;
+        f(&mut handler);
+        GDBTestBuilder { assert, handler, listener }
+    }
+
+    /// Run the prepared test, panicing on failure.
+    fn execute(self) {
+        let GDBTestBuilder { assert, handler, listener } = self;
+        let assert = assert.with_args(&["-ex", "quit"]);
+        // Run the server on a background thread.
+        let handle = thread::spawn(move || {
+            let (stream, _) = listener.accept().expect("Listener's accept failed!");
+            process_packets_from(stream.try_clone().expect("TCPStream::try_clone failed!"),
+                                 stream, handler);
+        });
+        assert.unwrap();
+        handle.join().expect("Failed to join server thread!");
+    }
+}
+
+/// Create a `GDBTestBuilder` and return it.
+fn gdb_test() -> GDBTestBuilder {
+    // First, ensure that we have a GDB binary.
+    let gdb = which::which("gdb").expect("Couldn't locate gdb!");
+    let gdb_s = gdb.to_string_lossy();
+    // Next, create a TCP socket to listen on.
+    let listener = TcpListener::bind("0.0.0.0:0").expect("Failed to bind TCP listen socket!");
+    let addr = listener.local_addr().expect("Failed to get listen socket address!");
+    let remote_cmd = format!("target remote {}", addr);
+    let assert = Assert::command(&[&gdb_s, "-nx", "-batch", "-ex", &remote_cmd]);
+    let handler = Default::default();
+    GDBTestBuilder { assert, handler, listener }
+}
+
+#[test]
+fn simple() {
+    // GDB will not do much with a process that has already exited, which is the default
+    // stop_reason.
+    gdb_test().assert(|a| a.stderr().contains("The target is not running")).execute()
+}


### PR DESCRIPTION
and a very basic test that passes. Add gdb to the travis-ci environment so the test can run.