### PR TITLE
Implement qXfer

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ log = "0.4.1"
 nom = "3.2.0"
 strum = "0.8.0"
 strum_macros = "0.8.0"
+memchr = "2.3.3"
 
 [dev-dependencies]
 assert_cli = "0.5.4"


### PR DESCRIPTION
This packet can be used for loading `target.xml` automatically! For my toy gdbserver implementation I used to force people to write `set tdesc filename <path>` :smile: 