### PR TITLE
Make libc optional feature (+ `cargo fmt`)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ strum_macros = "0.8.0"
 bitflags = "1.0"
 byteorder = "1.2"
 memchr = "2.3.3"
-libc = "0.2.71"
+libc = { version = "0.2.71", optional = true }
 num-derive = "0.3.0"
 num-traits = "0.2.12"
 

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -1,12 +1,7 @@
 //! Filesystem APIs for GDB, vFile
 
 use bitflags::bitflags;
-use std::{
-    convert::TryFrom,
-    ffi::CString,
-    io::{self, prelude::*},
-    mem::MaybeUninit,
-};
+use std::io::{self, prelude::*};
 
 /// Errno values for Host I/O operations.
 #[derive(Debug)]
@@ -170,14 +165,32 @@ pub fn read_stat(v: &[u8]) -> io::Result<HostStat> {
     let st_mtime = r.read_u32::<BigEndian>()?;
     let st_ctime = r.read_u32::<BigEndian>()?;
 
-    Ok(HostStat{ st_dev, st_ino, st_mode, st_nlink, st_uid, st_gid, st_rdev,
-                 st_size, st_blksize, st_blocks, st_atime, st_mtime, st_ctime })
+    Ok(HostStat {
+        st_dev,
+        st_ino,
+        st_mode,
+        st_nlink,
+        st_uid,
+        st_gid,
+        st_rdev,
+        st_size,
+        st_blksize,
+        st_blocks,
+        st_atime,
+        st_mtime,
+        st_ctime,
+    })
 }
 
 /// TODO: doc
 pub trait FileSystem {
     /// Open a file on the remote stub's current filesystem.
-    fn host_open(&self, _filename: Vec<u8>, _flags: HostOpenFlags, _mode: HostMode) -> IOResult<u64> {
+    fn host_open(
+        &self,
+        _filename: Vec<u8>,
+        _flags: HostOpenFlags,
+        _mode: HostMode,
+    ) -> IOResult<u64> {
         Err(())
     }
 
@@ -214,186 +227,6 @@ pub trait FileSystem {
     /// Set the current filesystem for subsequent host I/O requests.  If the
     /// given pid is 0, select the filesystem of the remote stub.  Otherwise,
     /// select the filesystem as seen by the process with the given pid.
-    fn host_setfs(&self, _pid: u64) -> IOResult<()> {
-        Err(())
-    }
-}
-
-/// A filesystem implementation that delegates all calls to libc. Basically,
-/// this lets you use the operating system's notion of files, which is probably
-/// what you want.
-#[derive(Debug, Default)]
-pub struct LibcFS {
-    /// don't initiate this struct outside of this crate, for future backwards
-    /// compatibility
-    _private: (),
-}
-
-macro_rules! map_flags {
-    ($inflags:ident: $intype:ident, $($inflag:ident => $outflag:expr,)*) => {{
-        let mut flags = 0;
-
-        {
-            $(if $inflags & $intype::$inflag == $intype::$inflag {
-                flags |= $outflag;
-            })*
-        }
-
-        flags
-    }};
-}
-
-fn errno() -> HostErrno {
-    match unsafe { *libc::__errno_location() } {
-        libc::EPERM => HostErrno::EPERM,
-        libc::ENOENT => HostErrno::ENOENT,
-        libc::EINTR => HostErrno::EINTR,
-        libc::EBADF => HostErrno::EBADF,
-        libc::EACCES => HostErrno::EACCES,
-        libc::EFAULT => HostErrno::EFAULT,
-        libc::EBUSY => HostErrno::EBUSY,
-        libc::EEXIST => HostErrno::EEXIST,
-        libc::ENODEV => HostErrno::ENODEV,
-        libc::ENOTDIR => HostErrno::ENOTDIR,
-        libc::EISDIR => HostErrno::EISDIR,
-        libc::EINVAL => HostErrno::EINVAL,
-        libc::ENFILE => HostErrno::ENFILE,
-        libc::EMFILE => HostErrno::EMFILE,
-        libc::EFBIG => HostErrno::EFBIG,
-        libc::ENOSPC => HostErrno::ENOSPC,
-        libc::ESPIPE => HostErrno::ESPIPE,
-        libc::EROFS => HostErrno::EROFS,
-        libc::ENAMETOOLONG => HostErrno::ENAMETOOLONG,
-        _ => HostErrno::EUNKNOWN,
-    }
-}
-
-impl FileSystem for LibcFS {
-    fn host_open(&self, filename: Vec<u8>, gdbflags: HostOpenFlags, gdbmode: HostMode) -> IOResult<u64> {
-        Ok((|| {
-            let filename = CString::new(filename).map_err(|_| HostErrno::ENOENT)?;
-
-            let flags = map_flags! {
-                gdbflags: HostOpenFlags,
-                O_RDONLY => libc::O_RDONLY,
-                O_WRONLY => libc::O_WRONLY,
-                O_RDWR   => libc::O_RDWR,
-                O_APPEND => libc::O_APPEND,
-                O_CREAT  => libc::O_CREAT,
-                O_TRUNC  => libc::O_TRUNC,
-                O_EXCL   => libc::O_EXCL,
-            };
-
-            let mode = map_flags! {
-                gdbmode: HostMode,
-                S_IFREG => libc::S_IFREG,
-                S_IFDIR => libc::S_IFDIR,
-                S_IRUSR => libc::S_IRUSR,
-                S_IWUSR => libc::S_IWUSR,
-                S_IXUSR => libc::S_IXUSR,
-                S_IRGRP => libc::S_IRGRP,
-                S_IWGRP => libc::S_IWGRP,
-                S_IXGRP => libc::S_IXGRP,
-                S_IROTH => libc::S_IROTH,
-                S_IWOTH => libc::S_IWOTH,
-                S_IXOTH => libc::S_IXOTH,
-            };
-
-            let fd: libc::c_int = unsafe { libc::open(filename.as_ptr(), flags, mode) };
-            if fd >= 0 {
-                Ok(u64::from(fd as u32))
-            } else {
-                Err(errno())
-            }
-        })())
-    }
-    fn host_close(&self, fd: u64) -> IOResult<()> {
-        Ok((|| {
-            if unsafe { libc::close(fd as libc::c_int) } == 0 {
-                Ok(())
-            } else {
-                Err(errno())
-            }
-        })())
-    }
-    fn host_pread(&self, fd: u64, count: u64, offset: u64) -> IOResult<Vec<u8>> {
-        Ok((|| {
-            // Allocate `count` (converted to usize) bytes
-            let count = usize::try_from(count).unwrap_or(std::usize::MAX);
-            let mut buf: Vec<u8> = Vec::with_capacity(count);
-
-            // Fill bytes as many as `read` bytes
-            let read: isize = unsafe {
-                libc::pread(
-                    fd as libc::c_int,
-                    buf.as_mut_ptr() as *mut libc::c_void,
-                    count,
-                    offset as libc::off_t,
-                )
-            };
-
-            if read >= 0 {
-                // Mark bytes up to `read` as initiated
-                unsafe {
-                    buf.set_len(read as usize);
-                }
-                Ok(buf)
-            } else {
-                Err(errno())
-            }
-        })())
-    }
-    fn host_pwrite(&self, fd: u64, offset: u64, data: Vec<u8>) -> IOResult<u64> {
-        Ok((|| {
-            // Write data, as much as `written` bytes of data
-            let written: isize = unsafe {
-                libc::pwrite(
-                    fd as libc::c_int,
-                    data.as_ptr() as *const libc::c_void,
-                    data.len(),
-                    offset as libc::off_t,
-                )
-            };
-
-            if written >= 0 {
-                Ok(written as u64)
-            } else {
-                Err(errno())
-            }
-        })())
-    }
-    fn host_fstat(&self, fd: u64) -> IOResult<HostStat> {
-        Ok((|| {
-            let mut stat: MaybeUninit<libc::stat> = MaybeUninit::uninit();
-
-            if unsafe { libc::fstat(fd as libc::c_int, stat.as_mut_ptr()) } == 0 {
-                let stat = unsafe { stat.assume_init() };
-                Ok(HostStat {
-                    st_dev: stat.st_dev as _,
-                    st_ino: stat.st_ino as _,
-                    st_mode: stat.st_mode as _,
-                    st_nlink: stat.st_nlink as _,
-                    st_uid: stat.st_uid as _,
-                    st_gid: stat.st_gid as _,
-                    st_rdev: stat.st_rdev as _,
-                    st_size: stat.st_size as _,
-                    st_blksize: stat.st_blksize as _,
-                    st_blocks: stat.st_blocks as _,
-                    st_atime: stat.st_atime as _,
-                    st_mtime: stat.st_mtime as _,
-                    st_ctime: stat.st_ctime as _,
-                })
-            } else {
-                Err(errno())
-            }
-        })())
-    }
-    fn host_unlink(&self, _filename: Vec<u8>) -> IOResult<()> {
-        Err(())
-    }
-    fn host_readlink(&self, _filename: Vec<u8>) -> IOResult<Vec<u8>> {
-        Err(())
-    }
     fn host_setfs(&self, _pid: u64) -> IOResult<()> {
         Err(())
     }

--- a/src/libc_fs.rs
+++ b/src/libc_fs.rs
@@ -1,0 +1,189 @@
+//! Filesystem APIs implemenation using libc
+
+use crate::fs::{FileSystem, HostErrno, HostMode, HostOpenFlags, HostStat, IOResult};
+use std::{convert::TryFrom, ffi::CString, mem::MaybeUninit};
+
+/// A filesystem implementation that delegates all calls to libc. Basically,
+/// this lets you use the operating system's notion of files, which is probably
+/// what you want.
+#[derive(Debug, Default)]
+pub struct LibcFS {
+    /// don't initiate this struct outside of this crate, for future backwards
+    /// compatibility
+    _private: (),
+}
+
+macro_rules! map_flags {
+    ($inflags:ident: $intype:ident, $($inflag:ident => $outflag:expr,)*) => {{
+        let mut flags = 0;
+
+        {
+            $(if $inflags & $intype::$inflag == $intype::$inflag {
+                flags |= $outflag;
+            })*
+        }
+
+        flags
+    }};
+}
+
+fn errno() -> HostErrno {
+    match unsafe { *libc::__errno_location() } {
+        libc::EPERM => HostErrno::EPERM,
+        libc::ENOENT => HostErrno::ENOENT,
+        libc::EINTR => HostErrno::EINTR,
+        libc::EBADF => HostErrno::EBADF,
+        libc::EACCES => HostErrno::EACCES,
+        libc::EFAULT => HostErrno::EFAULT,
+        libc::EBUSY => HostErrno::EBUSY,
+        libc::EEXIST => HostErrno::EEXIST,
+        libc::ENODEV => HostErrno::ENODEV,
+        libc::ENOTDIR => HostErrno::ENOTDIR,
+        libc::EISDIR => HostErrno::EISDIR,
+        libc::EINVAL => HostErrno::EINVAL,
+        libc::ENFILE => HostErrno::ENFILE,
+        libc::EMFILE => HostErrno::EMFILE,
+        libc::EFBIG => HostErrno::EFBIG,
+        libc::ENOSPC => HostErrno::ENOSPC,
+        libc::ESPIPE => HostErrno::ESPIPE,
+        libc::EROFS => HostErrno::EROFS,
+        libc::ENAMETOOLONG => HostErrno::ENAMETOOLONG,
+        _ => HostErrno::EUNKNOWN,
+    }
+}
+
+impl FileSystem for LibcFS {
+    fn host_open(
+        &self,
+        filename: Vec<u8>,
+        gdbflags: HostOpenFlags,
+        gdbmode: HostMode,
+    ) -> IOResult<u64> {
+        Ok((|| {
+            let filename = CString::new(filename).map_err(|_| HostErrno::ENOENT)?;
+
+            let flags = map_flags! {
+                gdbflags: HostOpenFlags,
+                O_RDONLY => libc::O_RDONLY,
+                O_WRONLY => libc::O_WRONLY,
+                O_RDWR   => libc::O_RDWR,
+                O_APPEND => libc::O_APPEND,
+                O_CREAT  => libc::O_CREAT,
+                O_TRUNC  => libc::O_TRUNC,
+                O_EXCL   => libc::O_EXCL,
+            };
+
+            let mode = map_flags! {
+                gdbmode: HostMode,
+                S_IFREG => libc::S_IFREG,
+                S_IFDIR => libc::S_IFDIR,
+                S_IRUSR => libc::S_IRUSR,
+                S_IWUSR => libc::S_IWUSR,
+                S_IXUSR => libc::S_IXUSR,
+                S_IRGRP => libc::S_IRGRP,
+                S_IWGRP => libc::S_IWGRP,
+                S_IXGRP => libc::S_IXGRP,
+                S_IROTH => libc::S_IROTH,
+                S_IWOTH => libc::S_IWOTH,
+                S_IXOTH => libc::S_IXOTH,
+            };
+
+            let fd: libc::c_int = unsafe { libc::open(filename.as_ptr(), flags, mode) };
+            if fd >= 0 {
+                Ok(u64::from(fd as u32))
+            } else {
+                Err(errno())
+            }
+        })())
+    }
+    fn host_close(&self, fd: u64) -> IOResult<()> {
+        Ok((|| {
+            if unsafe { libc::close(fd as libc::c_int) } == 0 {
+                Ok(())
+            } else {
+                Err(errno())
+            }
+        })())
+    }
+    fn host_pread(&self, fd: u64, count: u64, offset: u64) -> IOResult<Vec<u8>> {
+        Ok((|| {
+            // Allocate `count` (converted to usize) bytes
+            let count = usize::try_from(count).unwrap_or(std::usize::MAX);
+            let mut buf: Vec<u8> = Vec::with_capacity(count);
+
+            // Fill bytes as many as `read` bytes
+            let read: isize = unsafe {
+                libc::pread(
+                    fd as libc::c_int,
+                    buf.as_mut_ptr() as *mut libc::c_void,
+                    count,
+                    offset as libc::off_t,
+                )
+            };
+
+            if read >= 0 {
+                // Mark bytes up to `read` as initiated
+                unsafe {
+                    buf.set_len(read as usize);
+                }
+                Ok(buf)
+            } else {
+                Err(errno())
+            }
+        })())
+    }
+    fn host_pwrite(&self, fd: u64, offset: u64, data: Vec<u8>) -> IOResult<u64> {
+        Ok((|| {
+            // Write data, as much as `written` bytes of data
+            let written: isize = unsafe {
+                libc::pwrite(
+                    fd as libc::c_int,
+                    data.as_ptr() as *const libc::c_void,
+                    data.len(),
+                    offset as libc::off_t,
+                )
+            };
+
+            if written >= 0 {
+                Ok(written as u64)
+            } else {
+                Err(errno())
+            }
+        })())
+    }
+    fn host_fstat(&self, fd: u64) -> IOResult<HostStat> {
+        Ok((|| {
+            let mut stat: MaybeUninit<libc::stat> = MaybeUninit::uninit();
+
+            if unsafe { libc::fstat(fd as libc::c_int, stat.as_mut_ptr()) } == 0 {
+                let stat = unsafe { stat.assume_init() };
+                Ok(HostStat {
+                    st_dev: stat.st_dev as _,
+                    st_ino: stat.st_ino as _,
+                    st_mode: stat.st_mode as _,
+                    st_nlink: stat.st_nlink as _,
+                    st_uid: stat.st_uid as _,
+                    st_gid: stat.st_gid as _,
+                    st_rdev: stat.st_rdev as _,
+                    st_size: stat.st_size as _,
+                    st_blksize: stat.st_blksize as _,
+                    st_blocks: stat.st_blocks as _,
+                    st_atime: stat.st_atime as _,
+                    st_mtime: stat.st_mtime as _,
+                    st_ctime: stat.st_ctime as _,
+                })
+            } else {
+                Err(errno())
+            }
+        })())
+    }
+    fn host_unlink(&self, _filename: Vec<u8>) -> IOResult<()> {
+        Err(())
+    }
+    fn host_readlink(&self, _filename: Vec<u8>) -> IOResult<Vec<u8>> {
+        Err(())
+    }
+    fn host_setfs(&self, _pid: u64) -> IOResult<()> {
+        Err(())
+    }
+}

--- a/src/sigs.rs
+++ b/src/sigs.rs
@@ -152,6 +152,7 @@ pub enum Signal {
 
 impl Signal {
     /// Convert platform-specific libc signal to cross-platfrom GDB signals
+    #[cfg(feature = "libc")]
     pub fn from_libc(sig: libc::c_int) -> Option<Self> {
         match sig {
             libc::SIGHUP => Some(Self::SIGHUP),
@@ -189,6 +190,7 @@ impl Signal {
         }
     }
     /// Convert cross-platfrom GDB signals to platform-specific libc signals
+    #[cfg(feature = "libc")]
     pub fn to_libc(self) -> Option<libc::c_int> {
         match self {
             Self::SIGHUP => Some(libc::SIGHUP),


### PR DESCRIPTION
Currently the crate compiles only for linux, this makes it somewhat compatible with other platforms. 

Changes:
- add cfg! for libc code in sig.rs
- moves `LibcFS` without changes to libc_fs.rs
- makes libc optional
- `cargo fmt`