### PR TITLE
Add more command: continue, step, ...

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,7 @@ num-traits = "0.2.12"
 assert_cli = "0.5.4"
 env_logger = "0.4.3"
 which = "1.0.3"
+
+[features]
+all_stop = []
+lldb = []


### PR DESCRIPTION
Add support for:
- `qProcessInfo`
- `qRegisterInfo`
- `qSymbol`
- `c` -- continue
- `s` -- step

Extends support for 'H' -- supports different targets.